### PR TITLE
Implement basic shortest path robot strategy

### DIFF
--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/Action.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/Action.java
@@ -1,0 +1,15 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy;
+
+/**
+ * Describes the primitive actions the robot strategy can perform.
+ */
+public enum Action {
+    /** rotate 90 degrees to the left */
+    TURN_LEFT,
+    /** rotate 90 degrees to the right */
+    TURN_RIGHT,
+    /** move one tile forward */
+    STEP,
+    /** do nothing for one tick */
+    IDLE
+}

--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/GridPos.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/GridPos.java
@@ -1,0 +1,7 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy;
+
+/**
+ * Immutable grid coordinate helper used by strategies during path planning.
+ */
+public record GridPos(int x, int y) {
+}

--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/RobotRunner.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/RobotRunner.java
@@ -1,0 +1,142 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.GameStatusModel;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.Player;
+import de.uni_koblenz.ptsd.foxtrot.protocol.MazeGameProtocol;
+import javafx.application.Platform;
+
+/**
+ * Executes strategy decisions on a background thread and forwards actions to the protocol.
+ */
+public class RobotRunner {
+    private static final Logger LOG = Logger.getLogger(RobotRunner.class.getName());
+    private static final long COMMAND_INTERVAL_MS = 200L;
+    private static final long STRATEGY_TIMEOUT_MS = 1000L;
+
+    private final GameStatusModel model;
+    private final Player me;
+    private final MazeGameProtocol protocol;
+    private final Strategy strategy;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private Thread worker;
+
+    public RobotRunner(GameStatusModel model, Player me, MazeGameProtocol protocol, Strategy strategy) {
+        this.model = Objects.requireNonNull(model, "model");
+        this.me = Objects.requireNonNull(me, "player");
+        this.protocol = Objects.requireNonNull(protocol, "protocol");
+        this.strategy = Objects.requireNonNull(strategy, "strategy");
+    }
+
+    public synchronized void start() {
+        if (this.running.get()) {
+            return;
+        }
+        this.running.set(true);
+        this.strategy.reset();
+        this.worker = new Thread(this::runLoop, "RobotRunner");
+        this.worker.setDaemon(true);
+        this.worker.start();
+    }
+
+    public synchronized void stop() {
+        this.running.set(false);
+        if (this.worker != null) {
+            this.worker.interrupt();
+            try {
+                this.worker.join(TimeUnit.SECONDS.toMillis(1));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            this.worker = null;
+        }
+        // Ensure strategy state is cleared on the FX thread
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                this.strategy.reset();
+            } finally {
+                latch.countDown();
+            }
+        });
+        try {
+            latch.await(STRATEGY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public boolean isRunning() {
+        return this.running.get();
+    }
+
+    private void runLoop() {
+        while (this.running.get()) {
+            Action action = requestNextAction();
+            if (action == null || action == Action.IDLE) {
+                sleepQuietly(COMMAND_INTERVAL_MS);
+                continue;
+            }
+            try {
+                execute(action);
+            } catch (IOException e) {
+                LOG.log(Level.WARNING, "Failed to send robot command", e);
+                this.running.set(false);
+                break;
+            }
+            sleepQuietly(COMMAND_INTERVAL_MS);
+        }
+    }
+
+    private Action requestNextAction() {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Action> result = new AtomicReference<>(Action.IDLE);
+        Platform.runLater(() -> {
+            try {
+                result.set(this.strategy.decideNext(this.model, this.me));
+            } catch (Exception e) {
+                LOG.log(Level.WARNING, "Error while computing next robot action", e);
+                result.set(Action.IDLE);
+            } finally {
+                latch.countDown();
+            }
+        });
+        try {
+            if (!latch.await(STRATEGY_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                LOG.warning("Timed out waiting for strategy decision");
+                return Action.IDLE;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return Action.IDLE;
+        }
+        return result.get();
+    }
+
+    private void execute(Action action) throws IOException {
+        switch (action) {
+        case STEP -> this.protocol.sendStep();
+        case TURN_LEFT -> this.protocol.sendTurn('l');
+        case TURN_RIGHT -> this.protocol.sendTurn('r');
+        case IDLE -> {
+            // nothing to do
+        }
+        }
+    }
+
+    private void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/Strategy.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/Strategy.java
@@ -1,0 +1,24 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy;
+
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.GameStatusModel;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.Player;
+
+/**
+ * A robot strategy decides what to do next based on the current model state.
+ */
+public interface Strategy {
+
+    /**
+     * Determines the next action the robot should perform.
+     *
+     * @param model the shared game status model (never {@code null})
+     * @param me    the player entity representing the controlled robot (never {@code null})
+     * @return the action to execute; never {@code null}
+     */
+    Action decideNext(GameStatusModel model, Player me);
+
+    /**
+     * Resets any internal state so that a new planning cycle can begin.
+     */
+    void reset();
+}

--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/StrategyMode.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/StrategyMode.java
@@ -1,0 +1,10 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy;
+
+/**
+ * Available automation modes for the robot runner.
+ */
+public enum StrategyMode {
+    OFF,
+    ASTAR,
+    SMART
+}

--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/impl/ShortestPathStrategy.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/impl/ShortestPathStrategy.java
@@ -1,0 +1,274 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy.impl;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.enums.BaitType;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.enums.CellType;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.enums.Direction;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.Bait;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.GameStatusModel;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.Maze;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.Player;
+import de.uni_koblenz.ptsd.foxtrot.robot.strategy.Action;
+import de.uni_koblenz.ptsd.foxtrot.robot.strategy.GridPos;
+import de.uni_koblenz.ptsd.foxtrot.robot.strategy.Strategy;
+import javafx.collections.ObservableMap;
+
+/**
+ * Extremely small A*-like strategy that simply walks the shortest path to the nearest safe bait.
+ */
+public class ShortestPathStrategy implements Strategy {
+    private final Deque<Action> currentPlan = new ArrayDeque<>();
+    private GridPos currentTarget;
+
+    @Override
+    public Action decideNext(GameStatusModel model, Player me) {
+        Objects.requireNonNull(model, "model");
+        Objects.requireNonNull(me, "player");
+
+        if (needsReplan(model)) {
+            rebuildPlan(model, me);
+        }
+
+        if (this.currentPlan.isEmpty()) {
+            return Action.IDLE;
+        }
+
+        return this.currentPlan.pollFirst();
+    }
+
+    @Override
+    public void reset() {
+        this.currentPlan.clear();
+        this.currentTarget = null;
+    }
+
+    private boolean needsReplan(GameStatusModel model) {
+        if (this.currentPlan.isEmpty() || this.currentTarget == null) {
+            return true;
+        }
+        ObservableMap<Integer, Bait> baits = model.getBaits();
+        if (baits == null || baits.isEmpty()) {
+            return true;
+        }
+        return baits.values().stream().noneMatch(b -> b != null && b.isVisible()
+                && b.getBaitType() != BaitType.TRAP && isAtTarget(b));
+    }
+
+    private void rebuildPlan(GameStatusModel model, Player me) {
+        this.currentPlan.clear();
+        this.currentTarget = null;
+
+        Maze maze = model.getMaze();
+        if (maze == null) {
+            return;
+        }
+        ObservableMap<Integer, Bait> baitMap = model.getBaits();
+        if (baitMap == null || baitMap.isEmpty()) {
+            return;
+        }
+
+        List<Bait> candidates = new ArrayList<>();
+        for (Bait bait : baitMap.values()) {
+            if (bait == null || !bait.isVisible() || bait.getBaitType() == BaitType.TRAP) {
+                continue;
+            }
+            candidates.add(bait);
+        }
+        if (candidates.isEmpty()) {
+            return;
+        }
+
+        GridPos start = new GridPos(me.getxPosition(), me.getyPosition());
+        Direction startDir = me.getDirection() != null ? me.getDirection() : Direction.N;
+        Map<GridPos, List<GridPos>> paths = new HashMap<>();
+        Set<GridPos> traps = collectTrapPositions(baitMap.values());
+
+        int bestLength = Integer.MAX_VALUE;
+        List<GridPos> bestPath = null;
+        GridPos bestTarget = null;
+        for (Bait bait : candidates) {
+            GridPos goal = new GridPos(bait.getxPosition(), bait.getyPosition());
+            List<GridPos> path = paths.computeIfAbsent(goal, key -> findShortestPath(maze, start, key, traps));
+            if (path == null) {
+                continue;
+            }
+            int pathLength = path.size() - 1; // tiles to move
+            if (pathLength < bestLength) {
+                bestLength = pathLength;
+                bestPath = path;
+                bestTarget = goal;
+            }
+        }
+
+        if (bestPath == null || bestPath.size() < 2) {
+            return;
+        }
+
+        this.currentPlan.addAll(convertPathToActions(bestPath, startDir));
+        this.currentTarget = bestTarget;
+    }
+
+    private boolean isAtTarget(Bait bait) {
+        return this.currentTarget != null && bait.getxPosition() == this.currentTarget.x()
+                && bait.getyPosition() == this.currentTarget.y();
+    }
+
+    private Set<GridPos> collectTrapPositions(Iterable<Bait> baits) {
+        Set<GridPos> traps = new HashSet<>();
+        for (Bait bait : baits) {
+            if (bait != null && bait.isVisible() && bait.getBaitType() == BaitType.TRAP) {
+                traps.add(new GridPos(bait.getxPosition(), bait.getyPosition()));
+            }
+        }
+        return traps;
+    }
+
+    private List<GridPos> findShortestPath(Maze maze, GridPos start, GridPos goal, Set<GridPos> traps) {
+        int width = maze.getWidth();
+        int height = maze.getHeight();
+        boolean[][] visited = new boolean[height][width];
+        Queue<GridPos> queue = new ArrayDeque<>();
+        Map<GridPos, GridPos> parent = new HashMap<>();
+
+        queue.add(start);
+        visited[start.y()][start.x()] = true;
+
+        while (!queue.isEmpty()) {
+            GridPos current = queue.poll();
+            if (current.equals(goal)) {
+                break;
+            }
+            for (GridPos next : neighbours(current)) {
+                if (!inBounds(next, width, height)) {
+                    continue;
+                }
+                if (visited[next.y()][next.x()]) {
+                    continue;
+                }
+                if (!isWalkable(maze, next, traps, goal, start)) {
+                    continue;
+                }
+                visited[next.y()][next.x()] = true;
+                parent.put(next, current);
+                queue.add(next);
+            }
+        }
+
+        if (!visited[goal.y()][goal.x()]) {
+            return null;
+        }
+
+        LinkedList<GridPos> path = new LinkedList<>();
+        GridPos step = goal;
+        path.addFirst(step);
+        while (!step.equals(start)) {
+            step = parent.get(step);
+            if (step == null) {
+                return null;
+            }
+            path.addFirst(step);
+        }
+        return path;
+    }
+
+    private boolean isWalkable(Maze maze, GridPos pos, Set<GridPos> traps, GridPos goal, GridPos start) {
+        if (!pos.equals(goal) && traps.contains(pos)) {
+            return false;
+        }
+        CellType type = maze.getTypeAt(pos.x(), pos.y());
+        if (pos.equals(start)) {
+            return type != CellType.WALL && type != CellType.WATER;
+        }
+        return type == CellType.PATH;
+    }
+
+    private boolean inBounds(GridPos pos, int width, int height) {
+        return pos.x() >= 0 && pos.x() < width && pos.y() >= 0 && pos.y() < height;
+    }
+
+    private List<GridPos> neighbours(GridPos pos) {
+        List<GridPos> neighbours = new ArrayList<>(4);
+        neighbours.add(new GridPos(pos.x(), pos.y() - 1));
+        neighbours.add(new GridPos(pos.x() + 1, pos.y()));
+        neighbours.add(new GridPos(pos.x(), pos.y() + 1));
+        neighbours.add(new GridPos(pos.x() - 1, pos.y()));
+        return neighbours;
+    }
+
+    private Deque<Action> convertPathToActions(List<GridPos> path, Direction startDir) {
+        Deque<Action> actions = new ArrayDeque<>();
+        Direction dir = startDir;
+        GridPos current = path.get(0);
+        for (int i = 1; i < path.size(); i++) {
+            GridPos next = path.get(i);
+            Direction needed = directionTowards(current, next);
+            if (needed == null) {
+                return new ArrayDeque<>();
+            }
+            addTurns(actions, dir, needed);
+            dir = needed;
+            actions.add(Action.STEP);
+            current = next;
+        }
+        return actions;
+    }
+
+    private Direction directionTowards(GridPos from, GridPos to) {
+        int dx = to.x() - from.x();
+        int dy = to.y() - from.y();
+        if (dx == 1 && dy == 0) {
+            return Direction.E;
+        }
+        if (dx == -1 && dy == 0) {
+            return Direction.W;
+        }
+        if (dx == 0 && dy == 1) {
+            return Direction.S;
+        }
+        if (dx == 0 && dy == -1) {
+            return Direction.N;
+        }
+        return null;
+    }
+
+    private void addTurns(Deque<Action> actions, Direction current, Direction needed) {
+        if (current == needed) {
+            return;
+        }
+        int currentIdx = directionIndex(current);
+        int targetIdx = directionIndex(needed);
+        int diff = (targetIdx - currentIdx + 4) % 4;
+        switch (diff) {
+        case 0 -> {
+        }
+        case 1 -> actions.add(Action.TURN_RIGHT);
+        case 2 -> {
+            actions.add(Action.TURN_RIGHT);
+            actions.add(Action.TURN_RIGHT);
+        }
+        case 3 -> actions.add(Action.TURN_LEFT);
+        default -> {
+        }
+        }
+    }
+
+    private int directionIndex(Direction dir) {
+        return switch (dir) {
+        case N -> 0;
+        case E -> 1;
+        case S -> 2;
+        case W -> 3;
+        };
+    }
+}

--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/impl/StrategyFactory.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/impl/StrategyFactory.java
@@ -1,0 +1,22 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy.impl;
+
+import de.uni_koblenz.ptsd.foxtrot.robot.strategy.Strategy;
+import de.uni_koblenz.ptsd.foxtrot.robot.strategy.StrategyMode;
+
+/**
+ * Creates strategy implementations for the requested mode.
+ */
+public final class StrategyFactory {
+    private StrategyFactory() {
+    }
+
+    public static Strategy create(StrategyMode mode) {
+        if (mode == null) {
+            return null;
+        }
+        return switch (mode) {
+        case OFF -> null;
+        case ASTAR, SMART -> new ShortestPathStrategy();
+        };
+    }
+}

--- a/RobotStrategy/src/module-info.java
+++ b/RobotStrategy/src/module-info.java
@@ -1,0 +1,10 @@
+module RobotStrategy {
+    requires transitive GameStatusModel;
+    requires transitive MazeGameProtocol;
+    requires javafx.base;
+    requires javafx.graphics;
+    requires java.logging;
+
+    exports de.uni_koblenz.ptsd.foxtrot.robot.strategy;
+    exports de.uni_koblenz.ptsd.foxtrot.robot.strategy.impl;
+}


### PR DESCRIPTION
## Summary
- add the RobotStrategy module with shared types for actions, strategies and runner orchestration
- implement a shortest path strategy that selects the nearest visible, non-trap bait and plans a path avoiding walls, water and traps

## Testing
- mvn -pl RobotStrategy -am test *(fails: cannot download maven-resources-plugin because the build environment blocks network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cae6459f30832b8ae6d1a596f82745