### PR TITLE
Add detailed logging to robot strategy module

### DIFF
--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/Action.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/Action.java
@@ -1,0 +1,15 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy;
+
+/**
+ * Describes the primitive actions the robot strategy can perform.
+ */
+public enum Action {
+    /** rotate 90 degrees to the left */
+    TURN_LEFT,
+    /** rotate 90 degrees to the right */
+    TURN_RIGHT,
+    /** move one tile forward */
+    STEP,
+    /** do nothing for one tick */
+    IDLE
+}

--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/GridPos.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/GridPos.java
@@ -1,0 +1,7 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy;
+
+/**
+ * Immutable grid coordinate helper used by strategies during path planning.
+ */
+public record GridPos(int x, int y) {
+}

--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/RobotRunner.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/RobotRunner.java
@@ -1,0 +1,161 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.GameStatusModel;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.Player;
+import de.uni_koblenz.ptsd.foxtrot.protocol.MazeGameProtocol;
+import javafx.application.Platform;
+
+/**
+ * Executes strategy decisions on a background thread and forwards actions to the protocol.
+ */
+public class RobotRunner {
+    private static final Logger LOG = Logger.getLogger(RobotRunner.class.getName());
+    private static final long COMMAND_INTERVAL_MS = 200L;
+    private static final long STRATEGY_TIMEOUT_MS = 1000L;
+
+    private final GameStatusModel model;
+    private final Player me;
+    private final MazeGameProtocol protocol;
+    private final Strategy strategy;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private Thread worker;
+
+    public RobotRunner(GameStatusModel model, Player me, MazeGameProtocol protocol, Strategy strategy) {
+        this.model = Objects.requireNonNull(model, "model");
+        this.me = Objects.requireNonNull(me, "player");
+        this.protocol = Objects.requireNonNull(protocol, "protocol");
+        this.strategy = Objects.requireNonNull(strategy, "strategy");
+    }
+
+    public synchronized void start() {
+        if (this.running.get()) {
+            LOG.fine("RobotRunner already running – ignoring start request");
+            return;
+        }
+        this.running.set(true);
+        this.strategy.reset();
+        this.worker = new Thread(this::runLoop, "RobotRunner");
+        this.worker.setDaemon(true);
+        this.worker.start();
+        LOG.info(() -> String.format("RobotRunner started with strategy %s", this.strategy.getClass().getSimpleName()));
+    }
+
+    public synchronized void stop() {
+        if (!this.running.get()) {
+            LOG.fine("RobotRunner already stopped – ignoring stop request");
+        }
+        this.running.set(false);
+        if (this.worker != null) {
+            this.worker.interrupt();
+            try {
+                this.worker.join(TimeUnit.SECONDS.toMillis(1));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            this.worker = null;
+        }
+        // Ensure strategy state is cleared on the FX thread
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                this.strategy.reset();
+            } finally {
+                latch.countDown();
+            }
+        });
+        try {
+            latch.await(STRATEGY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        LOG.info("RobotRunner stopped");
+    }
+
+    public boolean isRunning() {
+        return this.running.get();
+    }
+
+    private void runLoop() {
+        while (this.running.get()) {
+            Action action = requestNextAction();
+            if (action == null || action == Action.IDLE) {
+                if (LOG.isLoggable(Level.FINER)) {
+                    LOG.finer("Strategy requested IDLE action – waiting before next poll");
+                }
+                sleepQuietly(COMMAND_INTERVAL_MS);
+                continue;
+            }
+            try {
+                if (LOG.isLoggable(Level.FINE)) {
+                    LOG.fine(() -> String.format("Executing action %s", action));
+                }
+                execute(action);
+            } catch (IOException e) {
+                LOG.log(Level.WARNING, "Failed to send robot command", e);
+                this.running.set(false);
+                break;
+            }
+            sleepQuietly(COMMAND_INTERVAL_MS);
+        }
+    }
+
+    private Action requestNextAction() {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Action> result = new AtomicReference<>(Action.IDLE);
+        Platform.runLater(() -> {
+            try {
+                if (LOG.isLoggable(Level.FINEST)) {
+                    LOG.finest("Requesting next action from strategy on FX thread");
+                }
+                result.set(this.strategy.decideNext(this.model, this.me));
+            } catch (Exception e) {
+                LOG.log(Level.WARNING, "Error while computing next robot action", e);
+                result.set(Action.IDLE);
+            } finally {
+                latch.countDown();
+            }
+        });
+        try {
+            if (!latch.await(STRATEGY_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                LOG.warning("Timed out waiting for strategy decision");
+                return Action.IDLE;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return Action.IDLE;
+        }
+        Action decided = result.get();
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.finer(() -> String.format("Strategy decided on action %s", decided));
+        }
+        return decided;
+    }
+
+    private void execute(Action action) throws IOException {
+        switch (action) {
+        case STEP -> this.protocol.sendStep();
+        case TURN_LEFT -> this.protocol.sendTurn('l');
+        case TURN_RIGHT -> this.protocol.sendTurn('r');
+        case IDLE -> {
+            // nothing to do
+        }
+        }
+    }
+
+    private void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/Strategy.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/Strategy.java
@@ -1,0 +1,24 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy;
+
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.GameStatusModel;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.Player;
+
+/**
+ * A robot strategy decides what to do next based on the current model state.
+ */
+public interface Strategy {
+
+    /**
+     * Determines the next action the robot should perform.
+     *
+     * @param model the shared game status model (never {@code null})
+     * @param me    the player entity representing the controlled robot (never {@code null})
+     * @return the action to execute; never {@code null}
+     */
+    Action decideNext(GameStatusModel model, Player me);
+
+    /**
+     * Resets any internal state so that a new planning cycle can begin.
+     */
+    void reset();
+}

--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/StrategyMode.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/StrategyMode.java
@@ -1,0 +1,10 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy;
+
+/**
+ * Available automation modes for the robot runner.
+ */
+public enum StrategyMode {
+    OFF,
+    ASTAR,
+    SMART
+}

--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/impl/ShortestPathStrategy.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/impl/ShortestPathStrategy.java
@@ -1,0 +1,351 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy.impl;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.enums.BaitType;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.enums.CellType;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.enums.Direction;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.Bait;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.GameStatusModel;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.Maze;
+import de.uni_koblenz.ptsd.foxtrot.gamestatus.model.Player;
+import de.uni_koblenz.ptsd.foxtrot.robot.strategy.Action;
+import de.uni_koblenz.ptsd.foxtrot.robot.strategy.GridPos;
+import de.uni_koblenz.ptsd.foxtrot.robot.strategy.Strategy;
+import javafx.collections.ObservableMap;
+
+/**
+ * Extremely small A*-like strategy that simply walks the shortest path to the nearest safe bait.
+ */
+public class ShortestPathStrategy implements Strategy {
+    private static final Logger LOG = Logger.getLogger(ShortestPathStrategy.class.getName());
+
+    private final Deque<Action> currentPlan = new ArrayDeque<>();
+    private GridPos currentTarget;
+
+    @Override
+    public Action decideNext(GameStatusModel model, Player me) {
+        Objects.requireNonNull(model, "model");
+        Objects.requireNonNull(me, "player");
+
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.finer(() -> String.format(
+                    "decideNext(): position=(%d,%d) direction=%s planSize=%d target=%s",
+                    me.getxPosition(), me.getyPosition(), me.getDirection(), this.currentPlan.size(),
+                    this.currentTarget));
+        }
+
+        if (needsReplan(model)) {
+            LOG.fine("Plan invalid or missing – triggering replanning");
+            rebuildPlan(model, me);
+        }
+
+        if (this.currentPlan.isEmpty()) {
+            LOG.fine("No plan available – returning IDLE");
+            return Action.IDLE;
+        }
+
+        Action next = this.currentPlan.pollFirst();
+        if (LOG.isLoggable(Level.FINE)) {
+            LOG.fine(() -> String.format("Next action: %s (remainingPlan=%s)", next,
+                    formatActions(this.currentPlan)));
+        }
+        return next;
+    }
+
+    @Override
+    public void reset() {
+        LOG.fine("Resetting strategy state");
+        this.currentPlan.clear();
+        this.currentTarget = null;
+    }
+
+    private boolean needsReplan(GameStatusModel model) {
+        if (this.currentPlan.isEmpty() || this.currentTarget == null) {
+            LOG.fine("Replan required: plan empty or target missing");
+            return true;
+        }
+        ObservableMap<Integer, Bait> baits = model.getBaits();
+        if (baits == null || baits.isEmpty()) {
+            LOG.fine("Replan required: no baits available in model");
+            return true;
+        }
+        boolean targetStillValid = baits.values().stream().anyMatch(
+                b -> b != null && b.isVisible() && b.getBaitType() != BaitType.TRAP && isAtTarget(b));
+        if (!targetStillValid) {
+            LOG.fine(() -> String.format("Replan required: current target %s no longer valid", this.currentTarget));
+        }
+        return !targetStillValid;
+    }
+
+    private void rebuildPlan(GameStatusModel model, Player me) {
+        if (LOG.isLoggable(Level.INFO)) {
+            LOG.info(() -> String.format("Rebuilding plan from position (%d,%d) direction=%s", me.getxPosition(),
+                    me.getyPosition(), me.getDirection()));
+        }
+        this.currentPlan.clear();
+        this.currentTarget = null;
+
+        Maze maze = model.getMaze();
+        if (maze == null) {
+            LOG.warning("Cannot rebuild plan: maze is null");
+            return;
+        }
+        ObservableMap<Integer, Bait> baitMap = model.getBaits();
+        if (baitMap == null || baitMap.isEmpty()) {
+            LOG.fine("Cannot rebuild plan: no baits available");
+            return;
+        }
+
+        List<Bait> candidates = new ArrayList<>();
+        for (Bait bait : baitMap.values()) {
+            if (bait == null || !bait.isVisible() || bait.getBaitType() == BaitType.TRAP) {
+                continue;
+            }
+            candidates.add(bait);
+        }
+        if (candidates.isEmpty()) {
+            LOG.fine("No visible non-trap bait candidates available");
+            return;
+        }
+
+        GridPos start = new GridPos(me.getxPosition(), me.getyPosition());
+        Direction startDir = me.getDirection() != null ? me.getDirection() : Direction.N;
+        Map<GridPos, List<GridPos>> paths = new HashMap<>();
+        Set<GridPos> traps = collectTrapPositions(baitMap.values());
+
+        int bestLength = Integer.MAX_VALUE;
+        List<GridPos> bestPath = null;
+        GridPos bestTarget = null;
+        for (Bait bait : candidates) {
+            GridPos goal = new GridPos(bait.getxPosition(), bait.getyPosition());
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.finer(() -> String.format("Evaluating bait at %s (type=%s)", goal, bait.getBaitType()));
+            }
+            List<GridPos> path = paths.computeIfAbsent(goal, key -> findShortestPath(maze, start, key, traps));
+            if (path == null) {
+                LOG.fine(() -> String.format("No path from %s to candidate %s", start, goal));
+                continue;
+            }
+            int pathLength = path.size() - 1; // tiles to move
+            if (pathLength < bestLength) {
+                bestLength = pathLength;
+                bestPath = path;
+                bestTarget = goal;
+                if (LOG.isLoggable(Level.FINE)) {
+                    LOG.fine(() -> String.format("New best target %s with path length %d (path=%s)", bestTarget,
+                            bestLength, formatPath(bestPath)));
+                }
+            }
+        }
+
+        if (bestPath == null || bestPath.size() < 2) {
+            LOG.warning("Rebuild failed: no viable path found to any bait");
+            return;
+        }
+
+        this.currentPlan.addAll(convertPathToActions(bestPath, startDir));
+        this.currentTarget = bestTarget;
+        if (LOG.isLoggable(Level.INFO)) {
+            LOG.info(() -> String.format("Planned path to %s with %d actions: %s", this.currentTarget,
+                    this.currentPlan.size(), formatActions(this.currentPlan)));
+        }
+    }
+
+    private boolean isAtTarget(Bait bait) {
+        return this.currentTarget != null && bait.getxPosition() == this.currentTarget.x()
+                && bait.getyPosition() == this.currentTarget.y();
+    }
+
+    private Set<GridPos> collectTrapPositions(Iterable<Bait> baits) {
+        Set<GridPos> traps = new HashSet<>();
+        for (Bait bait : baits) {
+            if (bait != null && bait.isVisible() && bait.getBaitType() == BaitType.TRAP) {
+                traps.add(new GridPos(bait.getxPosition(), bait.getyPosition()));
+            }
+        }
+        return traps;
+    }
+
+    private List<GridPos> findShortestPath(Maze maze, GridPos start, GridPos goal, Set<GridPos> traps) {
+        int width = maze.getWidth();
+        int height = maze.getHeight();
+        boolean[][] visited = new boolean[height][width];
+        Queue<GridPos> queue = new ArrayDeque<>();
+        Map<GridPos, GridPos> parent = new HashMap<>();
+
+        queue.add(start);
+        visited[start.y()][start.x()] = true;
+
+        while (!queue.isEmpty()) {
+            GridPos current = queue.poll();
+            if (current.equals(goal)) {
+                break;
+            }
+            for (GridPos next : neighbours(current)) {
+                if (!inBounds(next, width, height)) {
+                    continue;
+                }
+                if (visited[next.y()][next.x()]) {
+                    continue;
+                }
+                if (!isWalkable(maze, next, traps, goal, start)) {
+                    continue;
+                }
+                visited[next.y()][next.x()] = true;
+                parent.put(next, current);
+                queue.add(next);
+            }
+        }
+
+        if (!visited[goal.y()][goal.x()]) {
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.finer(() -> String.format("BFS terminated without reaching goal %s from %s", goal, start));
+            }
+            return null;
+        }
+
+        LinkedList<GridPos> path = new LinkedList<>();
+        GridPos step = goal;
+        path.addFirst(step);
+        while (!step.equals(start)) {
+            step = parent.get(step);
+            if (step == null) {
+                LOG.warning("Path reconstruction failed due to missing parent");
+                return null;
+            }
+            path.addFirst(step);
+        }
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.finer(() -> String.format("Found path: %s", formatPath(path)));
+        }
+        return path;
+    }
+
+    private boolean isWalkable(Maze maze, GridPos pos, Set<GridPos> traps, GridPos goal, GridPos start) {
+        if (!pos.equals(goal) && traps.contains(pos)) {
+            if (LOG.isLoggable(Level.FINEST)) {
+                LOG.finest(() -> String.format("Tile %s blocked because it is a visible trap", pos));
+            }
+            return false;
+        }
+        CellType type = maze.getTypeAt(pos.x(), pos.y());
+        if (pos.equals(start)) {
+            return type != CellType.WALL && type != CellType.WATER;
+        }
+        return type == CellType.PATH;
+    }
+
+    private boolean inBounds(GridPos pos, int width, int height) {
+        return pos.x() >= 0 && pos.x() < width && pos.y() >= 0 && pos.y() < height;
+    }
+
+    private List<GridPos> neighbours(GridPos pos) {
+        List<GridPos> neighbours = new ArrayList<>(4);
+        neighbours.add(new GridPos(pos.x(), pos.y() - 1));
+        neighbours.add(new GridPos(pos.x() + 1, pos.y()));
+        neighbours.add(new GridPos(pos.x(), pos.y() + 1));
+        neighbours.add(new GridPos(pos.x() - 1, pos.y()));
+        return neighbours;
+    }
+
+    private Deque<Action> convertPathToActions(List<GridPos> path, Direction startDir) {
+        Deque<Action> actions = new ArrayDeque<>();
+        Direction dir = startDir;
+        GridPos current = path.get(0);
+        for (int i = 1; i < path.size(); i++) {
+            GridPos next = path.get(i);
+            Direction needed = directionTowards(current, next);
+            if (needed == null) {
+                LOG.warning(() -> String.format("Non-adjacent steps in path between %s and %s", current, next));
+                return new ArrayDeque<>();
+            }
+            addTurns(actions, dir, needed);
+            dir = needed;
+            actions.add(Action.STEP);
+            current = next;
+        }
+        return actions;
+    }
+
+    private Direction directionTowards(GridPos from, GridPos to) {
+        int dx = to.x() - from.x();
+        int dy = to.y() - from.y();
+        if (dx == 1 && dy == 0) {
+            return Direction.E;
+        }
+        if (dx == -1 && dy == 0) {
+            return Direction.W;
+        }
+        if (dx == 0 && dy == 1) {
+            return Direction.S;
+        }
+        if (dx == 0 && dy == -1) {
+            return Direction.N;
+        }
+        return null;
+    }
+
+    private void addTurns(Deque<Action> actions, Direction current, Direction needed) {
+        if (current == needed) {
+            return;
+        }
+        int currentIdx = directionIndex(current);
+        int targetIdx = directionIndex(needed);
+        int diff = (targetIdx - currentIdx + 4) % 4;
+        switch (diff) {
+        case 0 -> {
+        }
+        case 1 -> {
+            actions.add(Action.TURN_RIGHT);
+            if (LOG.isLoggable(Level.FINEST)) {
+                LOG.finest(() -> String.format("Added TURN_RIGHT to rotate from %s to %s", current, needed));
+            }
+        }
+        case 2 -> {
+            actions.add(Action.TURN_RIGHT);
+            actions.add(Action.TURN_RIGHT);
+            if (LOG.isLoggable(Level.FINEST)) {
+                LOG.finest(() -> String.format("Added 180 degree turn from %s to %s", current, needed));
+            }
+        }
+        case 3 -> {
+            actions.add(Action.TURN_LEFT);
+            if (LOG.isLoggable(Level.FINEST)) {
+                LOG.finest(() -> String.format("Added TURN_LEFT to rotate from %s to %s", current, needed));
+            }
+        }
+        default -> {
+        }
+        }
+    }
+
+    private int directionIndex(Direction dir) {
+        return switch (dir) {
+        case N -> 0;
+        case E -> 1;
+        case S -> 2;
+        case W -> 3;
+        };
+    }
+
+    private static String formatPath(List<GridPos> path) {
+        return path == null ? "[]" : path.toString();
+    }
+
+    private static String formatActions(Deque<Action> actions) {
+        return actions == null ? "[]" : actions.toString();
+    }
+}

--- a/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/impl/StrategyFactory.java
+++ b/RobotStrategy/src/de/uni_koblenz/ptsd/foxtrot/robot/strategy/impl/StrategyFactory.java
@@ -1,0 +1,33 @@
+package de.uni_koblenz.ptsd.foxtrot.robot.strategy.impl;
+
+import java.util.logging.Logger;
+
+import de.uni_koblenz.ptsd.foxtrot.robot.strategy.Strategy;
+import de.uni_koblenz.ptsd.foxtrot.robot.strategy.StrategyMode;
+
+/**
+ * Creates strategy implementations for the requested mode.
+ */
+public final class StrategyFactory {
+    private static final Logger LOG = Logger.getLogger(StrategyFactory.class.getName());
+
+    private StrategyFactory() {
+    }
+
+    public static Strategy create(StrategyMode mode) {
+        if (mode == null) {
+            LOG.warning("Requested strategy for null mode");
+            return null;
+        }
+        Strategy strategy = switch (mode) {
+        case OFF -> null;
+        case ASTAR, SMART -> new ShortestPathStrategy();
+        };
+        if (strategy == null) {
+            LOG.info(() -> String.format("Strategy mode %s resolved to OFF", mode));
+        } else {
+            LOG.info(() -> String.format("Created strategy %s for mode %s", strategy.getClass().getSimpleName(), mode));
+        }
+        return strategy;
+    }
+}

--- a/RobotStrategy/src/module-info.java
+++ b/RobotStrategy/src/module-info.java
@@ -1,0 +1,10 @@
+module RobotStrategy {
+    requires transitive GameStatusModel;
+    requires transitive MazeGameProtocol;
+    requires javafx.base;
+    requires javafx.graphics;
+    requires java.logging;
+
+    exports de.uni_koblenz.ptsd.foxtrot.robot.strategy;
+    exports de.uni_koblenz.ptsd.foxtrot.robot.strategy.impl;
+}


### PR DESCRIPTION
## Summary
- add granular logging in RobotRunner to trace lifecycle and executed actions
- instrument ShortestPathStrategy with detailed planning, pathfinding and action queue logs
- log strategy creation decisions in StrategyFactory for easier debugging of selected modes

## Testing
- mvn -pl RobotStrategy -am test *(fails: Maven cannot download maven-resources-plugin because the build environment blocks network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cae6459f30832b8ae6d1a596f82745